### PR TITLE
☄️ add: useCopyToClipboard hook 

### DIFF
--- a/src/content/hooks/use-copy-to-clipboard.mdx
+++ b/src/content/hooks/use-copy-to-clipboard.mdx
@@ -1,0 +1,44 @@
+## Import
+
+```js
+import { useCopyToClipboard } from "@prismane/core/hooks";
+```
+
+## Usage
+
+```jsx
+function Demo() {
+    const [copiedValue, copyToClipboard] = useCopyToClipboard();
+
+    return (
+        <Flex direction="column" gap={fr(5)} align="center">
+            <Text
+                as="h1"
+                cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
+            >
+                Click to copy:
+            </Text>
+            <Flex gap={fr(3)}>
+                <Button onClick={() => copyToClipboard('Hey')}>Hey</Button>
+                <Button onClick={() => copyToClipboard('Sup')}>Sup</Button>
+                <Button onClick={() => copyToClipboard('Nice')}>Nice</Button>
+            </Flex>
+            <Text
+                fs="xl"
+                cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
+            >
+                Copied value: {value ?? 'Nothing is copied yet!'}
+            </Text>
+        </Flex>
+    );
+}
+```
+
+## API
+
+### Return Value
+
+| Name        | Type                         | Description                                                            |
+| ----------- | ---------------------------- | ---------------------------------------------------------------------- |
+| `copiedValue` | `string` | null |
+| `copyToClipboard` | `(text: string) => Promise<boolean>` | A function that attempts to copy the provided `text` to the clipboard. It returns a promise that resolves to `true` if the copy was successful, and `false` otherwise. If the browser does not support clipboard operations, it will log a warning and return false. If there is an error during copying, it will log a warning, set `copiedValue` to null, and return `false`. |

--- a/src/contentMap.ts
+++ b/src/contentMap.ts
@@ -1073,6 +1073,14 @@ const contentMap: any = [
           "useCounter hook provides a simple way to manage a stateful counter.",
       },
       {
+        slug: "use-copy-to-clipboard",
+        title: "useCopyToClipboard",
+
+        category: "state-management",
+        description:
+          "useCopyToClipboard hook provides a copyToClipboard method to save a string in the clipboard and the copiedValue value (default: null).",
+      },
+      {
         slug: "use-debounce",
         title: "useDebounce",
 

--- a/src/pages/docs/[category]/[slug].tsx
+++ b/src/pages/docs/[category]/[slug].tsx
@@ -103,6 +103,7 @@ import {
 import {
   useAnimation,
   useCounter,
+  useCopyToClipboard,
   useDebounce,
   useDimensions,
   useDraggable,
@@ -192,9 +193,8 @@ const HeadingLink = ({ children, ...props }: any) => {
   return (
     <NextLink
       href={href}
-      className={`flex items-center gap-2 group transition-all ${
-        children.type === "h2" ? "mt-10" : ""
-      } ${children.type === "h3" ? "mt-6" : ""}  docs-anchor`}
+      className={`flex items-center gap-2 group transition-all ${children.type === "h2" ? "mt-10" : ""
+        } ${children.type === "h3" ? "mt-6" : ""}  docs-anchor`}
       style={{ scrollMarginTop: "120px" }}
       id={id}
       {...props}
@@ -205,10 +205,10 @@ const HeadingLink = ({ children, ...props }: any) => {
           children.type === "h1"
             ? 32
             : children.type === "h2"
-            ? 24
-            : children.type === "h3"
-            ? 20
-            : 16
+              ? 24
+              : children.type === "h3"
+                ? 20
+                : 16
         }
         className="hidden group-hover:flex text-primary-500"
       />
@@ -317,6 +317,7 @@ export default function Page(params: any) {
                         fr,
                         useAnimation,
                         useCounter,
+                        useCopyToClipboard,
                         useDebounce,
                         useDimensions,
                         useDraggable,


### PR DESCRIPTION
Hey again, I tried to add that hook to the documentation as well, but I encountered some issues. Could you please take a look at the screenshots below?

not importing from prismane:
<img width="500" alt="Screenshot 2023-09-25 at 8 54 20 AM" src="https://github.com/spleafy/prismane-website/assets/96326525/13872f4a-c781-41a6-98a4-ae3b250e2b67">

here's how it looks: 
<img width="500" alt="Screenshot 2023-09-25 at 8 54 32 AM" src="https://github.com/spleafy/prismane-website/assets/96326525/31839186-fdf7-462b-aee8-136564b816d2">
